### PR TITLE
Replaced rawgit.com urls with combinatronics.com urls.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Clone the repository ([or download the zip](https://github.com/newsappsio/spam/r
 ```
 <script src="//d3js.org/d3.v3.min.js"></script>
 <script src="//d3js.org/topojson.v1.min.js"></script>
-<script src="//cdn.rawgit.com/mourner/rbush/master/rbush.js"></script>
-<script src="//cdn.rawgit.com/newsappsio/spam/master/spam.min.js"></script>
+<script src="//cdn.combinatronics.com/mourner/rbush/master/rbush.js"></script>
+<script src="//cdn.combinatronics.com/newsappsio/spam/master/spam.min.js"></script>
 ```
 
 Here's the most basic map you can do:


### PR DESCRIPTION
Combinatronics.com is a drop in replacement for rawgit.com which is EOL.